### PR TITLE
Add mention of @grant metadata key

### DIFF
--- a/api/gm.html
+++ b/api/gm.html
@@ -99,6 +99,7 @@
       <!-- Post Main Content -->
       <div class="entry-content">
         <p><code>GM_*</code> are a group of special APIs provided by Violentmonkey.</p>
+        <p>Access must be granted using the <a href="metadata-block.html#grant"><code>@grant</code></a> metadata key.</p>
 <h3 id="GM-info"><a href="#GM-info" class="headerlink" title="GM_info"></a>GM_info</h3><p>An object that exposes information about the current userscript. It has following properties:</p>
 <ul>
 <li><p><code>uuid</code></p>


### PR DESCRIPTION
A new user may not realize the @grant key is needed, since (if you don't use @grant) ViolentMonkey will only tell you that the method is not defined.