### PR TITLE
fix: make all param names bold + restore note's indent

### DIFF
--- a/content/pages/api/gm.md
+++ b/content/pages/api/gm.md
@@ -444,9 +444,9 @@ let control = GM_xmlhttpRequest(details)
     - `onreadystatechange` *function*
     - `ontimeout` *function*
 
-    > Note:
-    >
-    > - `synchronous` is not supported.
+> Note:
+>
+> - `synchronous` is not supported.
 
 Returns a control object with the following properties:
 

--- a/src/templates/page-template.css
+++ b/src/templates/page-template.css
@@ -6,6 +6,7 @@ li > p:nth-child(2) {
   margin-top: .25em;
 }
 
+li > .language-text:first-child,
 li > p:first-child > .language-text:first-child {
   font-weight: bold;
 }


### PR DESCRIPTION
Fixes the two things I've missed in the previous PR:

* bold param names in indented descriptions
* restore gm_xhr note's indent