### PR TITLE
fix: spelling of the argument

### DIFF
--- a/content/pages/api/gm.md
+++ b/content/pages/api/gm.md
@@ -392,7 +392,7 @@ let control = GM_xmlhttpRequest(details)
 
         Password for authentication.
 
-    - `overrideMimetype` *string*
+    - `overrideMimeType` *string*
 
         A MIME type to specify with the request.
 


### PR DESCRIPTION
Based on https://github.com/violentmonkey/violentmonkey/blob/246a16d79d807fec114fb3794d2daf17ca052ee2/src/injected/web/requests.js#L104
Case matters! 😢

Both GreaseMonkey and TamperMonkey use `overrideMimeType` but not `overrideMimetype`