### PR TITLE
feat: support GM/TM 'binary' option in GM_xmlhttpRequest

### DIFF
--- a/content/pages/api/gm.md
+++ b/content/pages/api/gm.md
@@ -426,6 +426,10 @@ let control = GM_xmlhttpRequest(details)
 
         Data to send with the request, usually for `POST` and `PUT` requests.
 
+    - `binary` *boolean* *(since VM2.12.2)*
+
+        Send the `data` string as a `blob`. This is for compatibility with Tampermonkey/Greasemonkey, where only `string` type is allowed in `data`.
+
     - `context` *any*
 
         Can be an object and will be assigned to `context` of the response object.


### PR DESCRIPTION
I'm assuming the option will be added (https://github.com/violentmonkey/violentmonkey/pull/708) in the next release and it'll be 2.12.2.