### PR TITLE
workaround for people struggling with throttling

### DIFF
--- a/content/posts/how-to-edit-scripts-with-your-favorite-editor/index.md
+++ b/content/posts/how-to-edit-scripts-with-your-favorite-editor/index.md
@@ -84,3 +84,16 @@ Known issues
 ---
 
 - Firefox may throttle detection: the older the file is, the longer it takes to detect the changes. See [this report](https://github.com/violentmonkey/violentmonkey/issues/460#issuecomment-434335758).
+- A workaround for instant un-throtteled updates:
+```js
+(...)
+// @grant       GM.xmlHttpRequest
+(...)
+GM.xmlHttpRequest({
+        method: "GET",
+        url: "file:///C:/path/to/script.js",
+        onload: function (response) {
+            eval(response.responseText);
+        }
+});
+```


### PR DESCRIPTION
For me, even the "track changes" button updates too slowly to be useful while developing, where I often make a small change, save, and refresh the page in a matter of seconds.

Found a workaround.