### PR TITLE
Fix Transifex link in localization

### DIFF
--- a/content/pages/localization/index.md
+++ b/content/pages/localization/index.md
@@ -10,7 +10,7 @@ We have automated weekly synchronization from Transifex, so the translations wil
 ## Transifex (Recommended)
 
 [👉🏻 Start translating or fix an existing translation.
-](https://www.transifex.com/violentmonkey/violentmonkey-nex/)
+](https://explore.transifex.com/violentmonkey/violentmonkey-nex/)
 
 ## Pull Requests
 


### PR DESCRIPTION
Hello @gera2ld,
this link was changed in #35, but looks like it's outdated again. I've used the link from the [latest Transifex fetch PR](https://github.com/violentmonkey/violentmonkey/pull/2361) on the main repo.