### PR TITLE
Clarify use of alpha characters in @version

### DIFF
--- a/content/pages/api/metadata-block.mdx
+++ b/content/pages/api/metadata-block.mdx
@@ -71,7 +71,7 @@ See [more about matching](../matching/).
 
 ### @version
 
-Version of the script, it can be used to check if a script has new versions. It is composed of several parts, joined by `.`. Each part must start with numbers, and can be followed by alphabetic characters.
+Version of the script, it can be used to check if a script has new versions. It is composed of several parts, joined by `.`. Each part must start with numbers, and *can* be followed by alphabetic characters (although these aren't used for version comparison).
 
 **Note:** If no `@version` is specified, the script will not be updated automatically.
 


### PR DESCRIPTION
Clarifies use of alpha characters in `@version` by stating they aren't used for comparison, see https://github.com/violentmonkey/violentmonkey/issues/2353#issuecomment-3364566111.

Thanks,
Elliott