### PR TITLE
fix: trivial grammar issue in brave mv2 warning

### DIFF
--- a/content/pages/index.mdx
+++ b/content/pages/index.mdx
@@ -31,7 +31,7 @@ Violentmonkey provides userscripts support for browsers.
 > [!WARNING]
 > [Violentmonkey BETA](https://chromewebstore.google.com/detail/violentmonkey-beta/opokoaglpekkimldnlggpoagmjegichg) is ManifestV3 now and after a test period will be published as stable. Meanwhile, you can re-enable your disabled stable version by downloading an MV3 zip from [our releases](https://github.com/violentmonkey/violentmonkey/releases) and adding `"key"` to its manifest.json as explained in the release description.
 >
-> **Brave** doesn't support installing Manifest V2 from the Chrome Web Store anymore.
+> **Brave** doesn't support installing Manifest V2 extensions from the Chrome Web Store anymore.
 > If you use Brave and need to export your data, **downgrade in place** to [v1.91.178](https://github.com/brave/brave-browser/releases/tag/v1.91.178) first to re-enable your extensions or use the MV3 test build and add `"key"` to its manifest.json as explained in the [release](https://github.com/violentmonkey/violentmonkey/releases/tag/v2.41.2).
 
 ## Installation


### PR DESCRIPTION
Introduced in b5ddb963236b33936821715c57c1437b64ae8c53.